### PR TITLE
Correct "cfg-if" crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ your code for non-release builds.
 `Cargo.toml`
 ```toml
 [dependencies]
-cfg_if = "0.1"
+cfg-if = "0.1"
 log = "0.4"
 console_log = { version = "0.2", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! cfg_if = "0.1"
+//! cfg-if = "0.1"
 //! log = "0.4"
 //! console_log = { version = "0.2", optional = true }
 //!


### PR DESCRIPTION
Just found this issue while following the README example. The underscore gives a "no matching package" error but the dash works.