### PR TITLE
force inline on needed functions for smaller binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console_log"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Matthew Nicholson <matt@matt-land.com>"]
 edition = "2018"
 keywords = ["log", "logging", "console", "web_sys", "wasm"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ static LOGGER: WebConsoleLogger = WebConsoleLogger {};
 struct WebConsoleLogger {}
 
 impl Log for WebConsoleLogger {
+    #[inline]
     fn enabled(&self, metadata: &Metadata) -> bool {
         metadata.level() <= log::max_level()
     }
@@ -141,6 +142,7 @@ impl Log for WebConsoleLogger {
 ///     .chain(fern::Output::call(console_log::log))
 ///     .apply()?;
 /// ```
+#[cfg_attr(not(feature = "color"), inline)]
 pub fn log(record: &Record) {
     #[cfg(not(feature = "color"))]
     {
@@ -208,6 +210,7 @@ pub fn log(record: &Record) {
 ///     console_log::init_with_level(Level::Debug).expect("error initializing logger");
 /// }
 /// ```
+#[inline]
 pub fn init_with_level(level: Level) -> Result<(), SetLoggerError> {
     log::set_logger(&LOGGER)?;
     log::set_max_level(level.to_level_filter());
@@ -223,6 +226,7 @@ pub fn init_with_level(level: Level) -> Result<(), SetLoggerError> {
 ///     console_log::init().expect("error initializing logger");
 /// }
 /// ```
+#[inline]
 pub fn init() -> Result<(), SetLoggerError> {
     init_with_level(Level::Info)
 }


### PR DESCRIPTION
These inline tags lead to 634 bytes total added size to binary with maximum optimization options for wasm while 1,412 bytes are added when these inline tags removed.
Although, case using `color` feature will not really going to be helped much.
Here are profile options used for size optimization.
```toml
[profile.release]
lto = true
opt-level = "z"
panic = "abort"
strip = "debuginfo"
codegen-units = 1
```
Also, `wee_alloc` crate was used for `#[global_allocator]`.