### PR TITLE
remove trailing semicolon from macro

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -16,7 +16,7 @@ impl Style<'static> {
     pub const fn default() -> Self {
         macro_rules! bg_color {
             ($color:expr) => {
-                concat!("color: white; padding: 0 3px; background: ", $color, ";");
+                concat!("color: white; padding: 0 3px; background: ", $color, ";")
             };
         };
 


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/issues/79813, trailing semicolons in expression macro bodies will eventually be made into a hard error. This PR is to remove the trailing semicolon.

I discovered this issue when I was running `cargo check --future-imcompat-report` on my binary crate which lists `console_log` as a dependency. Below is a snippet of the cargo output:

> warning: trailing semicolon in macro used in expression position
>   --> /Users/victorsuriel/.cargo/registry/src/github.com-1ecc6299db9ec823/console_log-0.2.1/src/style.rs:19:83
>    |
> 19 |                 concat!("color: white; padding: 0 3px; background: ", $color, ";");
> ...
> 24 |             trace: bg_color!("gray"),
>    |                    ----------------- in this macro invocation
>    |
>    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>    = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>    = note: this warning originates in the macro `bg_color` (in Nightly builds, run with -Z macro-backtrace for more info)
